### PR TITLE
Not require Typable s on DynLogicModel

### DIFF
--- a/src/Test/QuickCheck/DynamicLogic.hs
+++ b/src/Test/QuickCheck/DynamicLogic.hs
@@ -146,7 +146,7 @@ bracket (first:rest) = ["  ["++first++", "] ++
 -- properties at controlled times, so they are likely to fail if
 -- invoked at other times.
 
-class (Typeable s, StateModel s) => DynLogicModel s where
+class StateModel s => DynLogicModel s where
     restricted :: Action s a -> Bool
     restricted _ = False
 


### PR DESCRIPTION
This seems to be overly restrictive and does not allow parameterized
models where the type variable is not typable (e.g. an IOSim monad in
which actions are to be performed)