### PR TITLE
Generalize `postcondition`

### DIFF
--- a/quickcheck-dynamic/quickcheck-dynamic.cabal
+++ b/quickcheck-dynamic/quickcheck-dynamic.cabal
@@ -5,12 +5,12 @@ license:         Apache-2.0
 license-files:
   LICENSE
   NOTICE
-  
+
 maintainer:      arnaud.bailly@iohk.io
 author:          Ulf Norell
 category:        Testing
 synopsis:
-  A library for stateful property-based testing   
+  A library for stateful property-based testing
 homepage:
   https://github.com/input-output-hk/quickcheck-dynamic#readme
 
@@ -23,7 +23,7 @@ description:
 build-type:      Simple
 extra-doc-files: README.md
 extra-source-files: CHANGELOG.md
-                    
+
 source-repository head
   type:     git
   location: https://github.com/input-output-hk/quickcheck-dynamic
@@ -58,6 +58,7 @@ library
         Test.QuickCheck.DynamicLogic.SmartShrinking
         Test.QuickCheck.DynamicLogic.Utils
         Test.QuickCheck.StateModel
+        Test.QuickCheck.StateModel.Postcondition
     build-depends:
         QuickCheck -any,
         base >=4.7 && <5,

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -114,7 +114,7 @@ class
   -- by `perform`ing the `Action` inside the `state` so that further actions can use `Lookup`
   -- to retrieve that data. This allows the model to be ignorant of those values yet maintain
   -- some references that can be compared and looked for.
-  nextState :: state -> Action state a -> Var a -> state
+  nextState :: Typeable a => state -> Action state a -> Var a -> state
   nextState s _ _ = s
 
   -- | Precondition for filtering generated `Action`.

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Postcondition.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Postcondition.hs
@@ -1,0 +1,100 @@
+-- | Result of evaluation the postcondition
+--
+-- See 'Test.QuickCheck.StateModel.postcondition'.
+--
+-- Intended for qualified import.
+--
+-- > import Test.QuickCheck.StateModel.Postcondition (Postcondition(..))
+-- > import Test.QuickCheck.StateModel.Postcondition qualified as Post
+module Test.QuickCheck.StateModel.Postcondition (
+    Postcondition(..)
+    -- * Primitives
+  , assertSuccess
+  , assertFailure
+  , assertRelatedBy
+  , assertBool
+  , assertEQ
+  , assertLE
+  , assertLT
+  , assertLeft
+  , assertRight
+    -- * Combinators
+  , and
+  , all
+  , map
+  ) where
+
+import Prelude hiding (and, all, map)
+import Prelude qualified
+
+import Data.Bifunctor (bimap)
+import Data.Foldable (toList)
+import GHC.Show (appPrec1, showSpace)
+
+-- | Result of 'postcondition'
+newtype Postcondition = Postcondition { getPostcondition :: Either String () }
+  deriving (Show)
+
+{-------------------------------------------------------------------------------
+  Primitives
+-------------------------------------------------------------------------------}
+
+assertSuccess :: Postcondition
+assertSuccess = Postcondition $ Right ()
+
+assertFailure :: String -> Postcondition
+assertFailure = Postcondition . Left
+
+assertBool :: String -> Bool -> Postcondition
+assertBool _   True  = Postcondition $ Right ()
+assertBool msg False = assertFailure msg
+
+-- | Assert that two values are related by the given relation
+--
+-- The first argument should be a string representation representing the
+-- negated relation. For example:
+--
+-- > assertEqual = assertRelatedBy "/=" (==)
+assertRelatedBy :: Show a => String -> (a -> a -> Bool) -> a -> a -> Postcondition
+assertRelatedBy op f x y = Postcondition $
+    if f x y
+      then Right ()
+      else Left $ showsPrec appPrec1 x
+                . showSpace
+                . showString op
+                . showSpace
+                . showsPrec appPrec1 y
+                $ ""
+
+assertEQ :: (Eq a, Show a) => a -> a -> Postcondition
+assertEQ = assertRelatedBy "/=" (==)
+
+assertLT :: (Ord a, Show a) => a -> a -> Postcondition
+assertLT = assertRelatedBy ">=" (<)
+
+assertLE :: (Ord a, Show a) => a -> a -> Postcondition
+assertLE = assertRelatedBy ">" (<=)
+
+assertLeft :: Show b => Either a b -> Postcondition
+assertLeft (Left  _)  = assertSuccess
+assertLeft (Right b) = assertFailure $ "Expected Left: " ++ show b
+
+assertRight :: Show a => Either a b -> Postcondition
+assertRight (Right _) = assertSuccess
+assertRight (Left  a) = assertFailure $ "Expected Right: " ++ show a
+
+{-------------------------------------------------------------------------------
+  Combinators
+-------------------------------------------------------------------------------}
+
+map :: (String -> String) -> Postcondition -> Postcondition
+map f = Postcondition . bimap f id . getPostcondition
+
+and :: Foldable t => t Postcondition -> Postcondition
+and = Postcondition . sequence_ . Prelude.map getPostcondition . toList
+
+all :: forall t a. (Foldable t, Show a) => (a -> Postcondition) -> t a -> Postcondition
+all f = and . Prelude.map aux . toList
+  where
+    aux :: a -> Postcondition
+    aux a = map (\msg -> show a ++ ": " ++ msg) (f a)

--- a/quickcheck-io-sim-compat/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-io-sim-compat/test/Spec/DynamicLogic/RegistryModel.hs
@@ -126,15 +126,15 @@ instance StateModel RegState where
   precondition s (Successful act) = precondition s act
   precondition _ _ = True
 
-  postcondition _ Init _ _ = True
-  postcondition s (WhereIs name) env mtid =
+  postcondition _ Init _ _ = checkBool $ True
+  postcondition s (WhereIs name) env mtid = checkBool $
     (env <$> lookup name (regs s)) == mtid
-  postcondition _s Spawn _ _ = True
-  postcondition s (Register name step) _ res =
+  postcondition _s Spawn _ _ = checkBool $ True
+  postcondition s (Register name step) _ res = checkBool $
     positive s (Register name step) == isRight res
-  postcondition _s (Unregister _name) _ _ = True
-  postcondition _s (KillThread _) _ _ = True
-  postcondition _s (Successful (Register _ _)) _ res = isRight res
+  postcondition _s (Unregister _name) _ _ = checkBool $ True
+  postcondition _s (KillThread _) _ _ = checkBool $ True
+  postcondition _s (Successful (Register _ _)) _ res = checkBool $ isRight res
   postcondition s (Successful act) env res = postcondition s act env res
 
   monitoring (_s, s') act _ res =
@@ -151,6 +151,10 @@ instance StateModel RegState where
         Unregister _ -> tabu "Unregister" [case res of Left _ -> "fails"; Right () -> "succeeds"]
         WhereIs _ -> tabu "WhereIs" [case res of Nothing -> "fails"; Just _ -> "succeeds"]
         _ -> id
+
+checkBool :: Bool -> Maybe String
+checkBool True  = Nothing
+checkBool False = Just "condition failed"
 
 runModelIOSim :: forall s. RunModel RegState (IOSimModel (Registry (IOSim s)) s)
 runModelIOSim = RunModel performRegistry


### PR DESCRIPTION
This allows `postcondition` to return a string explaining the failure, rather than just a `Bool`. This will help with debugging.

I didn't bother taking advantage of this in the registry test, just added a function that turns a `Bool` into a  `Maybe String`. 