### PR TITLE
Refactoring to remove uncontroversial language extensions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: Build
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal update'
-        nix-shell --arg withoutDevTools true --run 'cabal build all'
+        nix-shell --arg withoutDevTools true --run 'cabal build all --ghc-options=-Werror'
 
     - name: Test
       run: |

--- a/quickcheck-dynamic-iosim/quickcheck-dynamic-iosim.cabal
+++ b/quickcheck-dynamic-iosim/quickcheck-dynamic-iosim.cabal
@@ -31,16 +31,17 @@ source-repository head
 common lang
   default-language:   Haskell2010
   default-extensions:
-    DeriveFoldable
-    DeriveFunctor
-    DeriveGeneric
-    DeriveLift
-    DeriveTraversable
-    ExplicitForAll
-    GeneralizedNewtypeDeriving
     ImportQualifiedPost
+    TypeFamilies
+    TypeApplications
+    RankNTypes
     ScopedTypeVariables
+    ConstraintKinds
+    FlexibleContexts
     StandaloneDeriving
+    FlexibleInstances
+    GADTs
+    MultiParamTypeClasses
 
   ghc-options:
     -Wall -Wnoncanonical-monad-instances -Wunused-packages
@@ -75,7 +76,8 @@ test-suite quickcheck-dynamic-iosim
         quickcheck-dynamic-iosim -any,
         tasty -any,
         tasty-test-reporter -any,
-        tasty-quickcheck -any,
+        -- TODO: include this when we turn on the tests again
+        -- tasty-quickcheck -any,
         io-classes,
         io-sim,
         mtl

--- a/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
+++ b/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
@@ -1,17 +1,4 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Test.QuickCheck.StateModel.IOSim where
 

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- A simple local name service for threads... behaves like the Erlang
 -- process registry.
 module Spec.DynamicLogic.Registry where

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -1,17 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Spec.DynamicLogic.RegistryModel where
 
 import Control.Concurrent (ThreadId)
@@ -30,7 +16,8 @@ import Test.QuickCheck
 import Test.QuickCheck.Gen.Unsafe (Capture (Capture), capture)
 import Test.QuickCheck.Monadic
 import Test.Tasty hiding (after)
-import Test.Tasty.QuickCheck (testProperty)
+-- TODO: include this when we turn on the tests again
+-- import Test.Tasty.QuickCheck (testProperty)
 
 import Spec.DynamicLogic.Registry
 import Test.QuickCheck.DynamicLogic.Core
@@ -103,7 +90,6 @@ instance StateModel RegState where
     Some act : [Some (Successful act') | Some act' <- shrinkAction s act]
   shrinkAction _ _ = []
 
-  initialState :: RegState
   initialState = RegState [] [] [] False
 
   nextState s Spawn step =

--- a/quickcheck-dynamic/quickcheck-dynamic.cabal
+++ b/quickcheck-dynamic/quickcheck-dynamic.cabal
@@ -31,16 +31,21 @@ source-repository head
 common lang
   default-language:   Haskell2010
   default-extensions:
-    DeriveFoldable
     DeriveFunctor
-    DeriveGeneric
-    DeriveLift
-    DeriveTraversable
-    ExplicitForAll
-    GeneralizedNewtypeDeriving
-    ImportQualifiedPost
-    ScopedTypeVariables
+    DeriveDataTypeable
     StandaloneDeriving
+    ImportQualifiedPost
+    TupleSections
+    LambdaCase
+    PatternSynonyms
+    GADTs
+    TypeApplications
+    ScopedTypeVariables
+    TypeFamilies
+    FlexibleContexts
+    FlexibleInstances
+    MultiParamTypeClasses
+    RankNTypes
 
   ghc-options:
     -Wall -Wnoncanonical-monad-instances -Wunused-packages

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 -- | Monadic interface for writing /Dynamic Logic/ properties.
 --
 -- This interface offers a much nicer experience than manipulating the

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Core.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Core.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 module Test.QuickCheck.DynamicLogic.Core (
   module Test.QuickCheck.DynamicLogic.Quantify,
   DynLogic,

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Quantify.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Quantify.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 -- | This module defines Quantifications, which are used together with

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -1,17 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Simple (stateful) Model-Based Testing library for use with Haskell QuickCheck.


### PR DESCRIPTION
This PR cleans up a bunch of code by moving (what I consider to be) "uncontroversial" language extensions to the cabal files and removes unnecessary language extensions that have been left over by chance.