### PR TITLE
Add `Typeable` constraint to `nextState`

### DIFF
--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -114,7 +114,7 @@ class
   -- by `perform`ing the `Action` inside the `state` so that further actions can use `Lookup`
   -- to retrieve that data. This allows the model to be ignorant of those values yet maintain
   -- some references that can be compared and looked for.
-  nextState :: state -> Action state a -> Var a -> state
+  nextState :: Typeable a => state -> Action state a -> Var a -> state
   nextState s _ _ = s
 
   -- | Precondition for filtering generated `Action`.


### PR DESCRIPTION
This was already satisfied in all call-sites, so this is a one-line change. For concrete tests, this constraint is not required because matching on the `Action` will reveal what `a` is, but it is necessary when defining polymorphic abstractions on top of `quickcheck-dynamic`.

Hopefully this is an uncontroversial change :) This is the minimum change I need to make the lockstep stuff work.