### PR TITLE
Bump `io-sim` dependency and fix registry test

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,8 +8,8 @@ tests: true
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/io-sim
-  tag: e4fd24f9336d63e6c734801e45378edd9483a3ec
-  --sha256: 0fldzjb0wp1d692gwkfh5ikba1g03vynxb17pzhg9f370izd2ya3
+  tag: 6b81d7c6f0d61b508f423ea93c9fd2085d5f7254
+  --sha256: 091mgpwm4bq2cbysmmvgwzdyzzycgmp5vznlwmlryj64mcmnd0wi
   subdir:
     io-classes
     io-sim

--- a/quickcheck-dynamic-iosim/quickcheck-dynamic-iosim.cabal
+++ b/quickcheck-dynamic-iosim/quickcheck-dynamic-iosim.cabal
@@ -76,8 +76,7 @@ test-suite quickcheck-dynamic-iosim
         quickcheck-dynamic-iosim -any,
         tasty -any,
         tasty-test-reporter -any,
-        -- TODO: include this when we turn on the tests again
-        -- tasty-quickcheck -any,
+        tasty-quickcheck -any,
         io-classes,
         io-sim,
         mtl

--- a/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
+++ b/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
@@ -4,25 +4,23 @@ module Test.QuickCheck.StateModel.IOSim where
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Monad.Class.MonadFork qualified as IOClass
-import Control.Monad.Class.MonadSTM qualified as IOClass
+import Control.Monad.Class.MonadFork     qualified as IOClass
+import Control.Monad.Class.MonadSTM      qualified as IOClass
+import Control.Concurrent.Class.MonadSTM.TVar qualified as IOClass
+import Control.Concurrent.Class.MonadSTM.TMVar qualified as IOClass
 import Control.Monad.IOSim
-
--- TODO: when we've updated the dependency on io-sim
--- import Control.Monad.Class.MonadMVar qualified as IOClass
 
 import Test.QuickCheck.StateModel
 
 type family RealizeIOSim s a where
   RealizeIOSim s ThreadId = IOClass.ThreadId (IOSim s)
   RealizeIOSim s (TVar a) = IOClass.TVar (IOSim s) a
--- TODO: when we've updated the dependency on io-sim
--- RealizeIOSim s (MVar a) = IOClass.MVar (IOSim s) a
+  RealizeIOSim s (MVar a) = IOClass.TMVar (IOSim s) a
 -- TODO: unfortunately no poly-kinded recursion for type families
 -- so we can't do something like :'(
--- RealizeIOSim s (f a)    = (RealizeIOSim f) (RealizeIOSim s a)
+-- RealizeIOSim s (f a)  = (RealizeIOSim f) (RealizeIOSim s a)
   RealizeIOSim s (f a b) = f (RealizeIOSim s a) (RealizeIOSim s b)
-  RealizeIOSim s (f a) = f (RealizeIOSim s a)
-  RealizeIOSim s a = a
+  RealizeIOSim s (f a)   = f (RealizeIOSim s a)
+  RealizeIOSim s a       = a
 
 type instance Realized (IOSim s) a = RealizeIOSim s a

--- a/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
+++ b/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
@@ -3,11 +3,10 @@
 module Test.QuickCheck.StateModel.IOSim where
 
 import Control.Concurrent
-import Control.Concurrent.STM
-import Control.Monad.Class.MonadFork     qualified as IOClass
-import Control.Monad.Class.MonadSTM      qualified as IOClass
-import Control.Concurrent.Class.MonadSTM.TVar qualified as IOClass
 import Control.Concurrent.Class.MonadSTM.TMVar qualified as IOClass
+import Control.Concurrent.Class.MonadSTM.TVar qualified as IOClass
+import Control.Concurrent.STM
+import Control.Monad.Class.MonadFork qualified as IOClass
 import Control.Monad.IOSim
 
 import Test.QuickCheck.StateModel
@@ -20,7 +19,7 @@ type family RealizeIOSim s a where
 -- so we can't do something like :'(
 -- RealizeIOSim s (f a)  = (RealizeIOSim f) (RealizeIOSim s a)
   RealizeIOSim s (f a b) = f (RealizeIOSim s a) (RealizeIOSim s b)
-  RealizeIOSim s (f a)   = f (RealizeIOSim s a)
-  RealizeIOSim s a       = a
+  RealizeIOSim s (f a) = f (RealizeIOSim s a)
+  RealizeIOSim s a = a
 
 type instance Realized (IOSim s) a = RealizeIOSim s a

--- a/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
+++ b/quickcheck-dynamic-iosim/src/Test/QuickCheck/StateModel/IOSim.hs
@@ -15,9 +15,6 @@ type family RealizeIOSim s a where
   RealizeIOSim s ThreadId = IOClass.ThreadId (IOSim s)
   RealizeIOSim s (TVar a) = IOClass.TVar (IOSim s) a
   RealizeIOSim s (MVar a) = IOClass.TMVar (IOSim s) a
--- TODO: unfortunately no poly-kinded recursion for type families
--- so we can't do something like :'(
--- RealizeIOSim s (f a)  = (RealizeIOSim f) (RealizeIOSim s a)
   RealizeIOSim s (f a b) = f (RealizeIOSim s a) (RealizeIOSim s b)
   RealizeIOSim s (f a) = f (RealizeIOSim s a)
   RealizeIOSim s a = a

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
@@ -2,12 +2,12 @@
 -- process registry.
 module Spec.DynamicLogic.Registry where
 
+import Control.Concurrent.Class.MonadSTM.TVar
 import Control.Monad
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadThrow
-import Control.Concurrent.Class.MonadSTM.TVar
-import GHC.Conc (ThreadStatus(..))
+import GHC.Conc (ThreadStatus (..))
 
 type Registry m = TVar m [(String, ThreadId m)]
 

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/Registry.hs
@@ -2,25 +2,21 @@
 -- process registry.
 module Spec.DynamicLogic.Registry where
 
--- import Control.Concurrent
 import Control.Monad
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadThrow
-
--- import Data.IORef
--- import GHC.Conc hiding (TVar)
--- import System.IO.Unsafe
+import Control.Concurrent.Class.MonadSTM.TVar
+import GHC.Conc (ThreadStatus(..))
 
 type Registry m = TVar m [(String, ThreadId m)]
 
 type MonadRegistry m = (MonadSTM m, MonadFork m, MonadThrow m, MonadFail m, MonadFail (STM m))
 
 alive :: MonadRegistry m => ThreadId m -> m Bool
-alive _ = do
-  -- s <- threadStatus tid
-  -- return $ s /= ThreadFinished && s /= ThreadDied
-  return True
+alive tid = do
+  s <- threadStatus tid
+  return $ s /= ThreadFinished && s /= ThreadDied
 
 setupRegistry :: forall m. MonadRegistry m => m (Registry m)
 setupRegistry = atomically $ newTVar @m []

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -108,7 +108,7 @@ instance StateModel RegState where
 
   precondition s Spawn = setup s
   precondition s WhereIs{} = setup s
-  precondition s (Register _name step) = setup s && step `elem` tids s -- && positive s (Register name step)
+  precondition s (Register name step) = setup s && step `elem` tids s && positive s (Register name step)
   precondition s Unregister{} = setup s
   precondition s (KillThread tid) = setup s && tid `elem` tids s
   precondition s (Successful act) = precondition s act

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -314,6 +314,7 @@ canReregister' s
 -- TODO:
 --  * add DL properties
 tests :: TestTree
-tests = testGroup
-  "registry model example"
-  [testProperty "prop_Registry" prop_Registry]
+tests =
+  testGroup
+    "registry model example"
+    [testProperty "prop_Registry" prop_Registry]

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -17,8 +17,7 @@ import Test.QuickCheck.Gen.Unsafe (Capture (Capture), capture)
 import Test.QuickCheck.Monadic
 import Test.Tasty hiding (after)
 
--- TODO: include this when we turn on the tests again
--- import Test.Tasty.QuickCheck (testProperty)
+import Test.Tasty.QuickCheck (testProperty)
 
 import Spec.DynamicLogic.Registry
 import Test.QuickCheck.DynamicLogic.Core
@@ -312,14 +311,9 @@ canReregister' s
  where
   availableTids = (tids s \\ map snd (regs s)) \\ dead s
 
-tests :: TestTree
-tests = testGroup "registry model example" []
-
 -- TODO:
---  * turn on this test
 --  * add DL properties
-{-
-testGroup
+tests :: TestTree
+tests = testGroup
   "registry model example"
   [testProperty "prop_Registry" prop_Registry]
--}


### PR DESCRIPTION
This PR bumps the `io-sim` dependency to include `threadStatus` in the interface. The idea is for the `Registry` example to start working. However, because we are running on a new scheduling semantics than the old funky version of the example this currently doesn't quite work - hence draft PR.