### PR TITLE
Conservative extension for negative testing

### DIFF
--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -57,7 +57,7 @@ instance StateModel RegState where
     name `Map.member` regs s
   precondition _ _ = True
 
-  negativePrecondition _ _ = True
+  validFailingAction _ _ = True
 
   arbitraryAction ctx s =
     frequency $

--- a/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic-iosim/test/Spec/DynamicLogic/RegistryModel.hs
@@ -134,7 +134,7 @@ instance m ~ RegM s => RunModel RegState m where
     pure $ isRight res
   postcondition _ _ _ _ = pure True
 
-  negativePostcondition (s, _) act@Register{} _ res = do
+  postconditionOnFailure (s, _) act@Register{} _ res = do
     monitorPost $
       tabulate
         "Reason for -Register"
@@ -142,7 +142,7 @@ instance m ~ RegM s => RunModel RegState m where
         | Left{} <- [res]
         ]
     pure $ isLeft res
-  negativePostcondition _s _ _ _ = pure True
+  postconditionOnFailure _s _ _ _ = pure True
 
   monitoring (_s, s') act@(showDictAction @s -> ShowDict) _ res =
     counterexample (show res ++ " <- " ++ show act ++ "\n  -- State: " ++ show s')

--- a/quickcheck-dynamic/CHANGELOG.md
+++ b/quickcheck-dynamic/CHANGELOG.md
@@ -9,9 +9,7 @@ changes.
 
 ## UNRELEASED
 
-## 3.2.0 - 2023-06-26
-
-* Added support for negative testing via `negative` and `negativePostcondition`
+* Added support for negative testing via `validFailingAction` and `postconditionOnFailure`
   callbacks in `StateModel` and `RunModel`.
 
 ## 3.1.1 - 2023-06-26

--- a/quickcheck-dynamic/CHANGELOG.md
+++ b/quickcheck-dynamic/CHANGELOG.md
@@ -9,6 +9,11 @@ changes.
 
 ## UNRELEASED
 
+## 3.2.0 - 2023-06-26
+
+* Added support for negative testing via `negative` and `negativePostcondition`
+  callbacks in `StateModel` and `RunModel`.
+
 ## 3.1.1 - 2023-06-26
 
 * Added instances for `HasVariables` with custom error messages to avoid the issue of

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
@@ -9,7 +9,7 @@
 module Test.QuickCheck.DynamicLogic (
   DL,
   action,
-  negativeAction,
+  failingAction,
   anyAction,
   anyActions,
   anyActions_,
@@ -63,8 +63,8 @@ instance MonadFail (DL s) where
 action :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s (Var a)
 action cmd = DL $ \_ k -> DL.after cmd k
 
-negativeAction :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s ()
-negativeAction cmd = DL $ \_ k -> DL.afterNegative cmd (k ())
+failingAction :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s ()
+failingAction cmd = DL $ \_ k -> DL.afterNegative cmd (k ())
 
 anyAction :: DL s ()
 anyAction = DL $ \_ k -> DL.afterAny $ k ()

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
@@ -9,6 +9,7 @@
 module Test.QuickCheck.DynamicLogic (
   DL,
   action,
+  negativeAction,
   anyAction,
   anyActions,
   anyActions_,
@@ -61,6 +62,9 @@ instance MonadFail (DL s) where
 
 action :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s (Var a)
 action cmd = DL $ \_ k -> DL.after cmd k
+
+negativeAction :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s ()
+negativeAction cmd = DL $ \_ k -> DL.afterNegative cmd (k ())
 
 anyAction :: DL s ()
 anyAction = DL $ \_ k -> DL.afterAny $ k ()

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Internal.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Internal.hs
@@ -306,7 +306,7 @@ instance StateModel s => Show (DynLogicTest s) where
         where
           f
             | p == PosPolarity = "action"
-            | otherwise = "negativeAction"
+            | otherwise = "failingAction"
   show (Looping ss) = prettyTestSequence (usedVariables ss) ss ++ "\n   pure ()\n   -- Looping"
   show (Stuck ss s) = prettyTestSequence (usedVariables ss) ss ++ "\n   pure ()\n   -- Stuck in state " ++ show s
   show (DLScript ss) = prettyTestSequence (usedVariables ss) ss ++ "\n   pure ()\n"

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Internal.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic/Internal.hs
@@ -80,8 +80,9 @@ after
   -> DynFormula s
 after act f = afterPolar (ActionWithPolarity act PosPolarity) f
 
--- | Given `f` must be `True` after /some/ action.
--- `f` is passed the state resulting from executing the `Action`.
+-- | Given `f` must be `True` after /some/ negative action.
+-- `f` is passed the state resulting from executing the `Action`
+-- as a negative action.
 afterNegative
   :: (Typeable a, Eq (Action s a), Show (Action s a))
   => Action s a


### PR DESCRIPTION
This gives you the ability to distinguish between "positive" actions and "negative" actions. Positive actions are on the "happy path" of your program while negative actions are expected to fail.

The simplest intuition for this model is that a positive action is one where the precondition succeeds and a negative action is any other action. A positive action evolves the model state via `nextState` and the concrete state via `perform`. A negative action meanwhile has no effect on the model state but evolves the concrete state via `perform`. However, to check that negative actions perform as expected (e.g. you get the "correct" 40x HTTP status code, the "correct" error etc.) you still get to run a `negativePostcondition`. Negative actions don't bind any variables.

However, for ease-of-use and backwards compatibility reasons you don't actually want the model described above. Instead, you want a model whereby you can control what negative actions actually run - and some times you want to update the model state to reflect some book-keeping or other information that you're interested in. For this reason we add `negativePrecondition` and `negativeNextState` with sensible default implementations.