### PR TITLE
Add instance of `HasVariables` for `Any f`.

### DIFF
--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Variables.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Variables.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.QuickCheck.StateModel.Variables (
@@ -57,6 +58,9 @@ instance (HasVariables k, HasVariables v) => HasVariables (Map k v) where
 
 instance HasVariables a => HasVariables (Set a) where
   getAllVariables = getAllVariables . Set.toList
+
+instance (forall a. HasVariables (f a)) => HasVariables (Any f) where
+  getAllVariables (Some a) = getAllVariables a
 
 newtype HasNoVariables a = HasNoVariables a
 


### PR DESCRIPTION
This is useful in case you have something like a `[Any (Action SomeState)]` in your state because you're doing something advanced like building a state model that transforms another state model in some way.

Checklist:
- [x] Check source-code formatting is consistent
