### PR TITLE
Update nix documentation the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,9 @@ This package uses [Cabal](https://www.haskell.org/cabal/)-based build. To build 
 
 This repository uses nix to provide a development and build environment.
 
-If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
-the flake config values to enable access to our binary caches.   
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to [this document](https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md). 
 
-The nix code is based on a template from the 
-[IOGX flake](https://github.com/input-output-hk/iogx). 
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
-of the IOGX manual.
+If you already have nix installed and configured, you may enter the development shell by running `nix develop`.
 
 * To enter a shell providing a complete haskell toolchain:
   ```

--- a/README.md
+++ b/README.md
@@ -47,13 +47,18 @@ This package uses [Cabal](https://www.haskell.org/cabal/)-based build. To build 
 
 ### With nix
 
-This repository comes with some [nix](https://nixos.org) files which might or might not help hacking on quickcheck-dynamic simpler.
-Before you start using nix, please make sure you've configured haskell.nix caching as per [those instructions](https://input-output-hk.github.io/haskell.nix/tutorials/getting-started.html#setting-up-the-binary-cache).
+This repository uses nix to provide a development and build environment.
 
-* Building with nix should be as simple as:
-  ```
-  nix build .#quickcheck-dynamic-lib-quickcheck-dynamic-ghc927
-  ```
+If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
+the flake config values to enable access to our binary caches.   
+
+The nix code is based on a template from the 
+[IOGX flake](https://github.com/input-output-hk/iogx). 
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
+of the IOGX manual.
+
 * To enter a shell providing a complete haskell toolchain:
   ```
   nix develop

--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -505,15 +505,16 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1698052499,
-        "narHash": "sha256-FoXYUaknObBfNoYaWt06Aq4pV+QvI0h1EXdzK4yutEg=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "98685364d646db5e7cb64bcbe9d455e8f2bb99d7",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {
@@ -730,6 +731,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -799,7 +816,7 @@
         "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR updates various files and documents that reference nix. 
