### PR TITLE
Expose only the class name for IsPerformResult

### DIFF
--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -25,6 +25,7 @@ module Test.QuickCheck.StateModel (
   Env,
   Realized,
   Generic,
+  IsPerformResult,
   monitorPost,
   counterexamplePost,
   stateAfter,


### PR DESCRIPTION
I hope this patch is not controversial! Let me know what you think.

```haskell
runActions :: forall state m e. (..., e Error state, forall a. IsPerformResult e a) => ...
```

The `IsPerformResult` name is internal, but this prevents one from using `runActions` in a context where `Error state` is not concrete. As an example, [in `quickcheck-lockstep` we wrap `runActions`](https://github.com/well-typed/quickcheck-lockstep/pull/20/files#diff-8b104867704d60785b4b5a7623aed0ea7b8aaec52da123fb07a4782b934affc5L99-R107), and so we need add the constraint there too. This use case is probably not exclusive to `quickcheck-lockstep`. 

Exposing the `IsPerformResult` name allows propagating the constraint, but one would not be able to provide new instances, so it wouldn't be unsafe to expose the name

If required, I can provide you with the GHC error in `quickcheck-lockstep` without the patch

Checklist:
- [x] Check source-code formatting is consistent
