### PR TITLE
Define phases of execution

### DIFF
--- a/quickcheck-dynamic/quickcheck-dynamic.cabal
+++ b/quickcheck-dynamic/quickcheck-dynamic.cabal
@@ -83,6 +83,7 @@ library
     , mtl
     , QuickCheck
     , random
+    , singletons
 
 test-suite quickcheck-dynamic-test
   import:         lang

--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
@@ -60,10 +60,10 @@ instance Monad (DL s) where
 instance MonadFail (DL s) where
   fail = errorDL
 
-action :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s (Var a)
+action :: (Typeable a, Eq (Action s Symbolic a), Show (Action s Symbolic a)) => Action s Symbolic a -> DL s (Var Symbolic a)
 action cmd = DL $ \_ k -> DL.after cmd k
 
-failingAction :: (Typeable a, Eq (Action s a), Show (Action s a)) => Action s a -> DL s ()
+failingAction :: (Typeable a, Eq (Action s Symbolic a), Show (Action s Symbolic a)) => Action s Symbolic a -> DL s ()
 failingAction cmd = DL $ \_ k -> DL.afterNegative cmd (k ())
 
 anyAction :: DL s ()
@@ -90,13 +90,13 @@ weight w = DL $ \s k -> DL.weight w (k () s)
 getSize :: DL s Int
 getSize = DL $ \s k -> DL.withSize $ \n -> k n s
 
-getModelStateDL :: DL s s
+getModelStateDL :: DL s (s Symbolic)
 getModelStateDL = DL $ \s k -> k (underlyingState s) s
 
 getVarContextDL :: DL s VarContext
 getVarContextDL = DL $ \s k -> k (vars s) s
 
-forAllVar :: forall a s. Typeable a => DL s (Var a)
+forAllVar :: forall a s. Typeable a => DL s (Var Symbolic a)
 forAllVar = do
   xs <- ctxAtType <$> getVarContextDL
   forAllQ $ elementsQ xs
@@ -114,7 +114,7 @@ errorDL name = DL $ \_ _ -> DL.errorDL name
 assert :: String -> Bool -> DL s ()
 assert name b = if b then return () else errorDL name
 
-assertModel :: String -> (s -> Bool) -> DL s ()
+assertModel :: String -> (s Symbolic -> Bool) -> DL s ()
 assertModel name p = assert name . p =<< getModelStateDL
 
 monitorDL :: (Property -> Property) -> DL s ()

--- a/quickcheck-dynamic/src/Test/QuickCheck/Extras.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/Extras.hs
@@ -2,6 +2,7 @@ module Test.QuickCheck.Extras where
 
 import Control.Monad.Reader
 import Control.Monad.State
+import Test.QuickCheck
 import Test.QuickCheck.Monadic
 
 runPropertyStateT :: Monad m => PropertyM (StateT s m) a -> s -> PropertyM m (a, s)
@@ -13,3 +14,7 @@ runPropertyReaderT :: Monad m => PropertyM (ReaderT e m) a -> e -> PropertyM m a
 runPropertyReaderT p e = MkPropertyM $ \k -> do
   m <- unPropertyM p $ fmap lift . k
   return $ runReaderT m e
+
+-- | Lifts a plain property into a monadic property.
+liftProperty :: Monad m => Property -> PropertyM m ()
+liftProperty prop = MkPropertyM (\k -> fmap (prop .&&.) <$> k ())

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -146,7 +146,7 @@ class
 
   -- | Precondition for filtering an `Action` that can meaningfully run but is supposed to fail.
   -- An action will run as a _negative_ action if the `precondition` fails and `validFailingAction` succeeds.
-  -- A negative action should have _no effect_ on the model state. This may not be desierable in all
+  -- A negative action should have _no effect_ on the model state. This may not be desirable in all
   -- situations - in which case one can override this semantics for book-keeping in `failureNextState`.
   validFailingAction :: state -> Action state a -> Bool
   validFailingAction _ _ = False
@@ -195,10 +195,14 @@ class (forall a. Show (Action state a), Monad m) => RunModel state m where
   postconditionOnFailure :: (state, state) -> Action state a -> LookUp -> Either (Error state) a -> Property
   postconditionOnFailure _ _ _ _ = property True
 
-  -- | Allows the user to attach additional information to the `Property` at each step of the process.
+  -- | Allows the user to attach additional information to the `Property` after each succesful run of an action.
   -- This function is given the full transition that's been executed, including the start and ending
   -- `state`, the `Action`, the current environment to `Lookup` and the value produced by `perform`
   -- while executing this step.
+  --
+  -- This is just a convenience as this information can as well be attached
+  -- to the property defined in @'postcondition'@ or @'postconditonOnFailure'@
+  -- with the same result.
   monitoring :: (state, state) -> Action state a -> LookUp -> Either (Error state) a -> Property -> Property
   monitoring _ _ _ _ prop = prop
 

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/Counters.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/Counters.hs
@@ -59,7 +59,7 @@ instance RunModel FailingCounter (ReaderT (IORef Int) IO) where
     ref <- ask
     lift $ atomicModifyIORef' ref (\count -> (succ count, count))
 
-  postcondition (_, FailingCounter{failingCount}) _ _ _ = pure $ failingCount < 4
+  postcondition (_, FailingCounter{failingCount}) _ _ _ = property $ failingCount < 4
 
 -- A generic but simple counter model
 data Counter = Counter Int
@@ -93,5 +93,5 @@ instance RunModel Counter (ReaderT (IORef Int) IO) where
       writeIORef ref 0
       pure n
 
-  postcondition (Counter n, _) Reset _ res = pure $ n == res
-  postcondition _ _ _ _ = pure True
+  postcondition (Counter n, _) Reset _ res = n === res
+  postcondition _ _ _ _ = property True

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -128,21 +128,18 @@ instance RunModel RegState RegM where
     lift $ threadDelay 100
     pure $ Right ()
 
-  postcondition (s, _) (WhereIs name) env mtid = do
-    pure $ (env <$> Map.lookup name (regs s)) == mtid
-  postcondition _ _ _ _ = pure True
-
-  postconditionOnFailure (s, _) act@Register{} _ res = do
-    monitorPost $
-      tabulate
-        "Reason for -Register"
-        [why s act]
-    pure $ isLeft res
-  postconditionOnFailure _s _ _ _ = pure True
-
-  monitoring (_s, s') act@(showDictAction -> ShowDict) _ res =
-    counterexample (show res ++ " <- " ++ show act ++ "\n  -- State: " ++ show s')
+  postcondition (s, s') act@(WhereIs name) env mtid =
+    counterexample (show mtid ++ " <- " ++ show act ++ "\n  -- State: " ++ show s')
       . tabulate "Registry size" [show $ Map.size (regs s')]
+      $ (env <$> Map.lookup name (regs s)) === mtid
+  postcondition _ _ _ _ = property True
+
+  postconditionOnFailure (s, _) act@Register{} _ res =
+    tabulate
+      "Reason for -Register"
+      [why s act]
+      $ isLeft res
+  postconditionOnFailure _s _ _ _ = property True
 
 data ShowDict a where
   ShowDict :: Show a => ShowDict a


### PR DESCRIPTION
Execution is now divided in two phases `Symbolic` and `Dynamic`. The conversion between both is done via `toDynAction` automatically once that one is provided.

Checklist:
- [ ] Check source-code formatting is consistent
