### PR TITLE
Move `Error state` to `RunModel`

### DIFF
--- a/quickcheck-dynamic/CHANGELOG.md
+++ b/quickcheck-dynamic/CHANGELOG.md
@@ -9,7 +9,7 @@ changes.
 
 ## UNRELEASED
 
-* Breaking removed `Realized`
+* **BREAKING**: Removed `Realized`
   - To migrate uses of `Realized` with `IOSim`, index the state type on the choice of `RunModel` monad
     and index the relevant types:
     ```
@@ -18,6 +18,8 @@ changes.
     -- Into:
     data ModelState m = State { threadId :: Var (ThreadId m) }
     ```
+* **BREAKING**: Moved `Error state` from `StateModel` to `RunModel` and indexed it on both the `state` and the monad `m`
+* **BREAKING**: Changed `PerformResult` from `PerformResult (Error state) a` to `PerformResult state m a`
 
 ## 3.4.1 - 2024-03-22
 

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -44,8 +44,6 @@ instance StateModel RegState where
     Unregister :: String -> Action RegState ()
     KillThread :: Var ThreadId -> Action RegState ()
 
-  type Error RegState = SomeException
-
   precondition s (Register name tid) =
     name `Map.notMember` regs s
       && tid `notElem` Map.elems (regs s)
@@ -110,6 +108,8 @@ instance StateModel RegState where
 type RegM = ReaderT Registry IO
 
 instance RunModel RegState RegM where
+  type Error RegState RegM = SomeException
+
   perform _ Spawn _ = do
     tid <- lift $ forkIO (threadDelay 10000000)
     pure $ Right tid


### PR DESCRIPTION
This ensures that we aren't mixing concepts. Thanks @ch1bo for pointing this out.