### PR TITLE
Introduce a QuickCheck-style `MoreActions` type modifier to make it easier to increase the number of actions on average in tests

### DIFF
--- a/quickcheck-dynamic/CHANGELOG.md
+++ b/quickcheck-dynamic/CHANGELOG.md
@@ -20,6 +20,7 @@ changes.
     ```
 * **BREAKING**: Moved `Error state` from `StateModel` to `RunModel` and indexed it on both the `state` and the monad `m`
 * **BREAKING**: Changed `PerformResult` from `PerformResult (Error state) a` to `PerformResult state m a`
+* Added a `moreActions` property modifier to allow controlling the length of action sequences.
 
 ## 3.4.1 - 2024-03-22
 

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -549,13 +549,13 @@ runActions
   => Actions state
   -> PropertyM m (Annotated state, Env)
 runActions (Actions_ rejected (Smart _ actions)) = do
-  -- TODO: consider bucketing one level lower here - 0-10, 10-20, ... 100-200, 200-300, ... 1000-2000, ...
-  -- insted
-  let bucket n
-        | b <= 0 = "0 - 9"
-        | otherwise = show ((10 :: Integer) ^ b) ++ " - " ++ show ((10 :: Integer) ^ (b + 1) - 1)
+  let bucket = \ n -> let (a, b) = go n in show a ++ " - " ++ show b
         where
-          b = floor (logBase 10 (fromIntegral n :: Double)) :: Integer
+          go n
+            | n < 100   = (d * 10, d * 10 + 9)
+            | otherwise = let (a, b) = go d in (a * 10, b * 10 + 9)
+            where
+              d = div n 10
   monitor $ tabulate "# of actions" [show $ bucket $ length actions]
   (finalState, env) <- runSteps initialAnnotatedState [] actions
   unless (null rejected) $

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -555,7 +555,7 @@ runActions (Actions_ rejected (Smart _ actions)) = do
         | b <= 0 = "0 - 9"
         | otherwise = show ((10 :: Integer) ^ b) ++ " - " ++ show ((10 :: Integer) ^ (b + 1) - 1)
         where
-          b = round (logBase 10 (fromIntegral n :: Double)) :: Integer
+          b = floor (logBase 10 (fromIntegral n :: Double)) :: Integer
   monitor $ tabulate "# of actions" [show $ bucket $ length actions]
   (finalState, env) <- runSteps initialAnnotatedState [] actions
   unless (null rejected) $

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -27,6 +27,7 @@ module Test.QuickCheck.StateModel (
   Generic,
   IsPerformResult,
   MoreActions (..),
+  GenActionsOptions (..),
   monitorPost,
   counterexamplePost,
   stateAfter,
@@ -39,6 +40,8 @@ module Test.QuickCheck.StateModel (
   computePrecondition,
   computeArbitraryAction,
   computeShrinkAction,
+  generateActionsWithOptions,
+  defaultGenActionsOptions,
 ) where
 
 import Control.Monad
@@ -379,6 +382,9 @@ instance forall state. StateModel state => Arbitrary (Actions state) where
               | otherwise = ps : map (p :) (go ps)
          in go acts
 
+-- | Introduce 10x more actions into every trace during testing. Can be used as
+-- `prop_Something . getMoreActions` to increase coverage when long actions sequences
+-- are necessary.
 newtype MoreActions state = MoreActions {getMoreActions :: Actions state}
 
 instance Show (Actions state) => Show (MoreActions state) where
@@ -395,6 +401,8 @@ data GenActionsOptions state = GenActionsOptions {genOptLengthMult :: Int}
 defaultGenActionsOptions :: GenActionsOptions state
 defaultGenActionsOptions = GenActionsOptions{genOptLengthMult = 1}
 
+-- | Generate arbitrary actions with the `GenActionsOptions`. More flexible than using the type-based
+-- modifiers.
 generateActionsWithOptions :: forall state. StateModel state => GenActionsOptions state -> Gen (Actions state)
 generateActionsWithOptions GenActionsOptions{..} = do
   (as, rejected) <- arbActions initialAnnotatedState 1

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -549,10 +549,10 @@ runActions
   => Actions state
   -> PropertyM m (Annotated state, Env)
 runActions (Actions_ rejected (Smart _ actions)) = do
-  let bucket = \ n -> let (a, b) = go n in show a ++ " - " ++ show b
+  let bucket = \n -> let (a, b) = go n in show a ++ " - " ++ show b
         where
           go n
-            | n < 100   = (d * 10, d * 10 + 9)
+            | n < 100 = (d * 10, d * 10 + 9)
             | otherwise = let (a, b) = go d in (a * 10, b * 10 + 9)
             where
               d = div n 10

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -267,7 +267,7 @@ tests =
   testGroup
     "registry model example"
     [ testProperty "prop_Registry" $ prop_Registry
-    , testProperty "prop_Registry . getMoreActions" $ withMaxSuccess 50 . prop_Registry . getMoreActions
+    , testProperty "prop_Registry . getMoreActions" $ moreActions 10 $ withMaxSuccess 50 . prop_Registry
     , testProperty "canRegister" $ propDL canRegister
     , testProperty "canRegisterNoUnregister" $ expectFailure $ propDL canRegisterNoUnregister
     ]

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -267,6 +267,7 @@ tests =
   testGroup
     "registry model example"
     [ testProperty "prop_Registry" $ prop_Registry
+    , testProperty "prop_Registry . getMoreActions" $ prop_Registry . getMoreActions
     , testProperty "canRegister" $ propDL canRegister
     , testProperty "canRegisterNoUnregister" $ expectFailure $ propDL canRegisterNoUnregister
     ]

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -267,7 +267,7 @@ tests =
   testGroup
     "registry model example"
     [ testProperty "prop_Registry" $ prop_Registry
-    , testProperty "prop_Registry . getMoreActions" $ moreActions 10 $ withMaxSuccess 50 . prop_Registry
+    , testProperty "moreActions 10 $ prop_Registry" $ moreActions 10 prop_Registry
     , testProperty "canRegister" $ propDL canRegister
     , testProperty "canRegisterNoUnregister" $ expectFailure $ propDL canRegisterNoUnregister
     ]

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -267,7 +267,7 @@ tests =
   testGroup
     "registry model example"
     [ testProperty "prop_Registry" $ prop_Registry
-    , testProperty "prop_Registry . getMoreActions" $ prop_Registry . getMoreActions
+    , testProperty "prop_Registry . getMoreActions" $ withMaxSuccess 50 . prop_Registry . getMoreActions
     , testProperty "canRegister" $ propDL canRegister
     , testProperty "canRegisterNoUnregister" $ expectFailure $ propDL canRegisterNoUnregister
     ]

--- a/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
+++ b/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
@@ -12,9 +12,9 @@ import Test.QuickCheck.Extras (runPropertyReaderT)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, pick)
 import Test.QuickCheck.StateModel (
   Actions,
-  MoreActions (..),
   lookUpVarMaybe,
   mkVar,
+  moreActions,
   runActions,
   underlyingState,
   viewAtType,
@@ -86,6 +86,4 @@ prop_failsOnPostcondition actions =
 
 prop_longSequences :: Property
 prop_longSequences =
-  checkCoverage $
-    forAll (arbitrary @(MoreActions SimpleCounter)) $ \(MoreActions (Actions steps)) ->
-      cover 50 (100 < length steps) "Long sequences" True
+  checkCoverage $ moreActions 10 $ \(Actions steps :: Actions SimpleCounter) -> cover 50 (100 < length steps) "Long sequences" True

--- a/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
+++ b/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
@@ -30,6 +30,7 @@ tests =
   testGroup
     "Running actions"
     [ testProperty "simple counter" $ prop_counter
+    , testProperty "simple_counter_moreActions" $ moreActions 30 prop_counter
     , testProperty "returns final state updated from actions" prop_returnsFinalState
     , testProperty "environment variables indices are 1-based " prop_variablesIndicesAre1Based
     , testCase "prints distribution of actions and polarity" $ do

--- a/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
+++ b/quickcheck-dynamic/test/Test/QuickCheck/StateModelSpec.hs
@@ -7,7 +7,7 @@ import Control.Monad.Reader (lift)
 import Data.IORef (newIORef)
 import Data.List (isInfixOf)
 import Spec.DynamicLogic.Counters (Counter (..), FailingCounter, SimpleCounter (..))
-import Test.QuickCheck (Property, Result (..), Testable, arbitrary, chatty, checkCoverage, choose, counterexample, cover, forAll, noShrinking, property, stdArgs)
+import Test.QuickCheck (Property, Result (..), Testable, chatty, checkCoverage, choose, counterexample, cover, noShrinking, property, stdArgs)
 import Test.QuickCheck.Extras (runPropertyReaderT)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, pick)
 import Test.QuickCheck.StateModel (
@@ -40,7 +40,7 @@ tests =
         Failure{output} <- captureTerminal prop_failsOnPostcondition
         "do action $ Inc'" `isInfixOf` output @? "Output does not contain \"do action $ Inc'\": " <> output
     , testProperty
-        "MoreActions introduces long sequences of actions"
+        "moreActions introduces long sequences of actions"
         prop_longSequences
     ]
 


### PR DESCRIPTION
I'm not 100% sure I like this design, but now you can do `quickCheck $ prop_BlaBla . getMoreActions` to increase the number of actions generated in traces without changing other stuff.

The thing I don't like about this is that it doesn't take into account wanting to add other modifiers at the same time. What if we wanted a modifier `PostiveActions` for polarity for example? `quickCheck $ prop_BlaBla . getMoreActions . getPositiveActions` would be a bit messy to implement as it stands now. Something to think about?

Checklist:
- [x] Check source-code formatting is consistent
