### PR TITLE
support QuickCheck-2.16

### DIFF
--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs
@@ -56,7 +56,8 @@ import Data.Monoid (Endo (..))
 import Data.Set qualified as Set
 import Data.Void
 import GHC.Generics
-import Test.QuickCheck as QC
+import Test.QuickCheck (Arbitrary, Gen, Property, Smart (..), Testable, counterexample, forAllShrink, frequency, property, resize, shrinkList, sized, tabulate)
+import Test.QuickCheck qualified as QC
 import Test.QuickCheck.DynamicLogic.SmartShrinking
 import Test.QuickCheck.Monadic
 import Test.QuickCheck.StateModel.Variables

--- a/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Variables.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/StateModel/Variables.hs
@@ -31,7 +31,7 @@ import Data.Set qualified as Set
 import GHC.Generics
 import GHC.TypeLits
 import GHC.Word
-import Test.QuickCheck as QC
+import Test.QuickCheck (Gen, Smart (..), elements)
 
 -- | A symbolic variable for a value of type `a`
 newtype Var a = Var Int

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/Counters.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/Counters.hs
@@ -6,7 +6,7 @@ module Spec.DynamicLogic.Counters where
 
 import Control.Monad.Reader
 import Data.IORef
-import Test.QuickCheck
+import Test.QuickCheck (frequency)
 import Test.QuickCheck.StateModel
 
 -- A very simple model with a single action that always succeed in

--- a/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
+++ b/quickcheck-dynamic/test/Spec/DynamicLogic/RegistryModel.hs
@@ -10,7 +10,8 @@ import Data.Either
 import Data.List
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Test.QuickCheck
+import Test.QuickCheck (Gen, Property)
+import Test.QuickCheck qualified as QC
 import Test.QuickCheck.Monadic hiding (assert)
 import Test.QuickCheck.Monadic qualified as QC
 import Test.Tasty hiding (after)
@@ -56,7 +57,7 @@ instance StateModel RegState where
 
   arbitraryAction ctx s =
     let threadIdCtx = ctxAtType @ThreadId ctx
-     in frequency $
+     in QC.frequency $
           [
             ( max 1 $ 10 - length threadIdCtx
             , return $ Some Spawn
@@ -135,15 +136,15 @@ instance RunModel RegState RegM where
 
   postconditionOnFailure (s, _) act@Register{} _ res = do
     monitorPost $
-      tabulate
+      QC.tabulate
         "Reason for -Register"
         [why s act]
     pure $ isLeft res
   postconditionOnFailure _s _ _ _ = pure True
 
   monitoring (_s, s') act@(showDictAction -> ShowDict) _ res =
-    counterexample (show res ++ " <- " ++ show act ++ "\n  -- State: " ++ show s')
-      . tabulate "Registry size" [show $ Map.size (regs s')]
+    QC.counterexample (show res ++ " <- " ++ show act ++ "\n  -- State: " ++ show s')
+      . QC.tabulate "Registry size" [show $ Map.size (regs s')]
 
 data ShowDict a where
   ShowDict :: Show a => ShowDict a
@@ -167,13 +168,13 @@ why s (Register name tid) =
 why _ _ = "(impossible)"
 
 arbitraryName :: Gen String
-arbitraryName = elements allNames
+arbitraryName = QC.elements allNames
 
 probablyRegistered :: RegState -> Gen String
-probablyRegistered s = oneof $ map pure (Map.keys $ regs s) ++ [arbitraryName]
+probablyRegistered s = QC.oneof $ map pure (Map.keys $ regs s) ++ [arbitraryName]
 
 probablyUnregistered :: RegState -> Gen String
-probablyUnregistered s = elements $ allNames ++ (allNames \\ Map.keys (regs s))
+probablyUnregistered s = QC.elements $ allNames ++ (allNames \\ Map.keys (regs s))
 
 shrinkName :: String -> [String]
 shrinkName name = [n | n <- allNames, n < name]
@@ -184,7 +185,7 @@ allNames = ["a", "b", "c", "d", "e"]
 prop_Registry :: Actions RegState -> Property
 prop_Registry s =
   monadicIO $ do
-    monitor $ counterexample "\nExecution\n"
+    monitor $ QC.counterexample "\nExecution\n"
     reg <- lift setupRegistry
     runPropertyReaderT (runActions s) reg
     QC.assert True
@@ -270,5 +271,5 @@ tests =
     [ testProperty "prop_Registry" $ prop_Registry
     , testProperty "moreActions 10 $ prop_Registry" $ moreActions 10 prop_Registry
     , testProperty "canRegister" $ propDL canRegister
-    , testProperty "canRegisterNoUnregister" $ expectFailure $ propDL canRegisterNoUnregister
+    , testProperty "canRegisterNoUnregister" $ QC.expectFailure $ propDL canRegisterNoUnregister
     ]


### PR DESCRIPTION
Fixes breaking build when using QuickCheck-2.16 due to clashing `Some` now exported from `Test.QuickCheck`

Checklist:
- [x] Check source-code formatting is consistent
